### PR TITLE
HEP-2134 substance UI | Flow Production Tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,4 @@ pip-log.txt
 # Max OS X Desktop Services Store files
 .DS_Store
 
-python/tk_substancepainter/__pycache__/
+__pycache__/

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ pip-log.txt
 
 # Max OS X Desktop Services Store files
 .DS_Store
+
+python/tk_substancepainter/__pycache__/

--- a/engine.py
+++ b/engine.py
@@ -362,7 +362,7 @@ class SubstancePainterEngine(Engine):
 
         # default menu name is Shotgun but this can be overridden
         # in the configuration to be sgtk in case of conflicts
-        self._menu_name = "Flow Production Tracking Toolkit (Formerly known as ShotGrid (Formerly known as Shotgun)) - (SGTK | FPTR)"
+        self._menu_name = "Flow Production Tracking"
         if self.get_setting("use_sgtk_as_menu_name", False):
             self._menu_name = "Sgtk"
 

--- a/python/tk_substancepainter/menu_generation.py
+++ b/python/tk_substancepainter/menu_generation.py
@@ -115,6 +115,28 @@ class MenuGenerator(object):
 
         # add menu to substance painter unless already present
         sp.ui.add_menu(self._menu_handle)
+        self._move_menu_to_front()
+
+    def _move_menu_to_front(self):
+
+        main_window = sp.ui.get_main_window()
+        if not main_window or not hasattr(main_window, "menuBar"):
+            return
+
+        menu_bar = main_window.menuBar()
+        if not menu_bar:
+            return
+
+        menu_action = self._menu_handle.menuAction()
+        actions = menu_bar.actions()
+
+        if menu_action not in actions or actions[0] == menu_action:
+            return
+
+        first_action = actions[0]
+        menu_bar.removeAction(menu_action)
+        menu_bar.insertAction(first_action, menu_action)
+
 
     def _add_sub_menu(self, menu_name, parent_menu):
         sub_menu = QtWidgets.QMenu(title=menu_name, parent=parent_menu)

--- a/python/tk_substancepainter/menu_generation.py
+++ b/python/tk_substancepainter/menu_generation.py
@@ -23,6 +23,7 @@ import unicodedata
 
 from PySide6 import QtWidgets, QtGui, QtCore, QtWebSockets, QtNetwork
 
+
 class MenuGenerator(object):
     """
     Menu generation functionality.
@@ -66,7 +67,7 @@ class MenuGenerator(object):
 
         # now enumerate all items and create menu objects for them
         menu_items = []
-        for (cmd_name, cmd_details) in self._engine.commands.items():
+        for cmd_name, cmd_details in self._engine.commands.items():
             menu_items.append(AppCommand(cmd_name, self, cmd_details))
 
         # sort list of commands in name order
@@ -115,9 +116,6 @@ class MenuGenerator(object):
 
         # add menu to substance painter unless already present
         sp.ui.add_menu(self._menu_handle)
-        self._move_menu_to_front()
-
-    def _move_menu_to_front(self):
 
         main_window = sp.ui.get_main_window()
         if not main_window or not hasattr(main_window, "menuBar"):
@@ -136,7 +134,6 @@ class MenuGenerator(object):
         first_action = actions[0]
         menu_bar.removeAction(menu_action)
         menu_bar.insertAction(first_action, menu_action)
-
 
     def _add_sub_menu(self, menu_name, parent_menu):
         sub_menu = QtWidgets.QMenu(title=menu_name, parent=parent_menu)
@@ -273,7 +270,7 @@ class AppCommand(object):
         app_instance = self.properties["app"]
         engine = app_instance.engine
 
-        for (app_instance_name, app_instance_obj) in engine.apps.items():
+        for app_instance_name, app_instance_obj in engine.apps.items():
             if app_instance_obj == app_instance:
                 # found our app!
                 return app_instance_name
@@ -289,6 +286,7 @@ class AppCommand(object):
             doc_url = app.documentation_url
             # deal with nuke's inability to handle unicode. #fail
             from tank_vendor import six
+
             if six.PY3:
                 from pyreadline.py3k_compat import unicode
 


### PR DESCRIPTION
Ticket
- [HEP-2134 substance UI | Flow Production Tracking](https://lavalmi.atlassian.net/jira/servicedesk/projects/HEP/queues/custom/321/HEP-2134)

Added Features:
- Changed _Flow Production Tracking Toolkit (Formerly known as ShotGrid (Formerly known as Shotgun)) - (SGTK | FPTR)_ to _Flow Production Tracking_. Put the menu option on first place in the menu bar.

Dev:
- [tk-substancepainter](https://github.com/lavalmi/tk-substancepainter)

Test Scenario
1. Start Flow Production Tracking Desktop
2. Select any project and run Substance Painter
3. Check if _Flow Production Tracking_ appears in the menu bar at the first place
